### PR TITLE
VA-1094 Use standard icon (eye) for showing the answer

### DIFF
--- a/guess-the-answer.js
+++ b/guess-the-answer.js
@@ -134,7 +134,7 @@ H5P.GuessTheAnswer = (function () {
     const solutionButton = H5P.Components.Button({
       label: params.solutionLabel,
       classes: 'show-solution-button',
-      icon: 'reveal-answer',
+      icon: 'show-solutions',
     });
 
     const title = Object.assign(document.createElement('div'), {


### PR DESCRIPTION
When merged in, will use the icon id for "show-solutions" instead of a redundant id that's to be removed in Components.